### PR TITLE
sepolicy: Apps need to read themed resources

### DIFF
--- a/sepolicy/app.te
+++ b/sepolicy/app.te
@@ -1,0 +1,3 @@
+# Themed resources (i.e. composed icons)
+allow appdomain theme_data_file:dir r_dir_perms;
+allow appdomain theme_data_file:file r_file_perms;

--- a/sepolicy/bootanim.te
+++ b/sepolicy/bootanim.te
@@ -1,0 +1,3 @@
+# Themed resources (bootanimation)
+allow bootanim theme_data_file:dir search;
+allow bootanim theme_data_file:file r_file_perms;

--- a/sepolicy/mediaserver.te
+++ b/sepolicy/mediaserver.te
@@ -1,0 +1,3 @@
+# Themed resources (i.e. composed icons)
+allow mediaserver theme_data_file:dir r_dir_perms;
+allow mediaserver theme_data_file:file r_file_perms;

--- a/sepolicy/sepolicy.mk
+++ b/sepolicy/sepolicy.mk
@@ -13,8 +13,10 @@ BOARD_SEPOLICY_UNION += \
     property_contexts \
     seapp_contexts \
     service_contexts \
-    auditd.te \
     adbd.te \
+    app.te \
+    auditd.te \
+    bootanim.te \
     healthd.te \
     hostapd.te \
     installd.te \
@@ -28,4 +30,5 @@ BOARD_SEPOLICY_UNION += \
     system_app.te \
     ueventd.te \
     vold.te \
+    zygote.te \
     mac_permissions.xml

--- a/sepolicy/zygote.te
+++ b/sepolicy/zygote.te
@@ -1,0 +1,3 @@
+allow zygote theme_data_file:file r_file_perms;
+allow zygote theme_data_file:dir r_dir_perms;
+


### PR DESCRIPTION
Assets such as composed icons and ringtones need to be accessed
by apps.  This patch adds the policy needed to facilitate this.

Change-Id: If47920b2cc5dbafe8d71a621782bb4a3351bd68c