### PR TITLE
common.mk: remove unused openvpn project

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -156,7 +156,6 @@ PRODUCT_PACKAGES += \
 # Extra tools in CM
 PRODUCT_PACKAGES += \
     libsepol \
-    openvpn \
     e2fsck \
     mke2fs \
     tune2fs \


### PR DESCRIPTION
this project does not exist in cm12 nor does it have a branch.
For cleanliness remove it

Change-Id: I956cb2e98b4e3fc0184cd614e180451a3d0b23d2
Signed-off-by: Simon Sickle <simon@simonsickle.com>