### PR TITLE
sepolicy: Allow system apps to write cache and media files

### DIFF
--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -3,5 +3,7 @@ allow system_app sysfs_devices_system_cpu:file rw_file_perms;
 allow system_app sysfs_devices_system_iosched:file rw_file_perms;
 
 # For the updaters
-allow system_app recovery_cache_file:dir {add_name rw_file_perms};
-allow system_app recovery_cache_file:file {create rw_file_perms};
+allow system_app recovery_cache_file:dir create_dir_perms;
+allow system_app recovery_cache_file:file create_file_perms;
+allow system_app media_rw_data_file:dir create_dir_perms;
+allow system_app media_rw_data_file:file create_file_perms;


### PR DESCRIPTION
Updaters need to be able to read and write to these locations.

Change-Id: I928a5f73ec29ab4fecb717072532d449192f3ca9